### PR TITLE
DEV-1543 update based on fragmentid

### DIFF
--- a/app/core/event_handler.py
+++ b/app/core/event_handler.py
@@ -13,28 +13,30 @@ log = logging.get_logger(__name__, config=config)
 async def handle_event(premis_event: PremisEvent) -> None:
     log.debug(
         "Start handling of PREMIS event.",
-        fragment_id=premis_event.fragment_id,
+        mediahaven_id=premis_event.mediahaven_id,
     )
 
     mediahaven_service = MediahavenService(config.app_cfg)
-    fragment_id = premis_event.fragment_id
+    mediahaven_id = premis_event.mediahaven_id
 
     # Get metadata for the newly archived item
     try:
-        fragment = mediahaven_service.get_fragment(fragment_id)
-        original_pid = fragment["Dynamic"]["s3_object_key"].split(".")[0]
+        fragment = mediahaven_service.get_fragment(mediahaven_id)
     except MediaObjectNotFoundException as e:
         log.critical(
-            "Got a PREMIS event, but the fragment id is not in MediaHaven",
-            fragment_id=premis_event.fragment_id,
+            "Got a PREMIS event, but the mediahaven id is not in MediaHaven",
+            mediahaven_id=premis_event.mediahaven_id,
             exception=str(e),
         )
         return
+    
+    try:
+        original_pid = fragment["Dynamic"]["s3_object_key"].split(".")[0]
+        fragment_id = fragment["Internal"]["FragmentId"]
     except KeyError as e:
         log.warning(
-            "s3_object_key is missing on the testbeeld item.",
-            fragment_id=premis_event.fragment_id,
-            exception=str(e),
+            f"{e} is missing on the testbeeld item.",
+            mediahaven_id=premis_event.mediahaven_id,
         )
         return
 
@@ -42,9 +44,9 @@ async def handle_event(premis_event: PremisEvent) -> None:
     try:
         original_metadata = mediahaven_service.query([("PID", original_pid)])
     except HTTPError as e:
-        log.critical(
+        log.warning(
             "Something went wrong querying Mediahaven for the original item.",
-            fragment_id=premis_event.fragment_id,
+            mediahaven_id=premis_event.mediahaven_id,
             original_pid=original_pid,
             exception=str(e),
         )
@@ -54,9 +56,9 @@ async def handle_event(premis_event: PremisEvent) -> None:
     try:
         sidecar = transform_mh_result_to_sidecar(original_metadata)
     except Exception as e:
-        log.critical(
+        log.warning(
             "Something went wrong transforming the original metadata.",
-            fragment_id=premis_event.fragment_id,
+            mediahaven_id=premis_event.mediahaven_id,
             original_pid=original_pid,
             original_metadata=original_metadata,
             exception=str(e),
@@ -67,9 +69,10 @@ async def handle_event(premis_event: PremisEvent) -> None:
     try:
         mediahaven_service.update_metadata(fragment_id, sidecar)
     except HTTPError as e:
-        log.critical(
+        log.warning(
             "Something went wrong while update testbeeld item with original metadata.",
-            fragment_id=premis_event.fragment_id,
+            mediahaven_id=premis_event.mediahaven_id,
+            fragment_id=fragment_id,
             original_pid=original_pid,
             original_metadata=original_metadata,
             new_metadata=sidecar,
@@ -80,6 +83,7 @@ async def handle_event(premis_event: PremisEvent) -> None:
     log.info(
         "Updated testbeeld item with original metadata.",
         fragment_id=fragment_id,
+        mediahaven_id=mediahaven_id,
         original_pid=original_pid,
         new_metadata=sidecar,
     )

--- a/app/core/event_handler.py
+++ b/app/core/event_handler.py
@@ -23,16 +23,16 @@ async def handle_event(premis_event: PremisEvent) -> None:
     try:
         fragment = mediahaven_service.get_fragment(mediahaven_id)
     except MediaObjectNotFoundException as e:
-        log.critical(
+        log.error(
             "Got a PREMIS event, but the mediahaven id is not in MediaHaven",
             mediahaven_id=premis_event.mediahaven_id,
             exception=str(e),
         )
         return
 
+    fragment_id = fragment["Internal"]["FragmentId"]
     try:
         original_pid = fragment["Dynamic"]["s3_object_key"].split(".")[0]
-        fragment_id = fragment["Internal"]["FragmentId"]
     except KeyError as e:
         log.warning(
             f"{e} is missing on the testbeeld item.",

--- a/app/core/event_handler.py
+++ b/app/core/event_handler.py
@@ -29,7 +29,7 @@ async def handle_event(premis_event: PremisEvent) -> None:
             exception=str(e),
         )
         return
-    
+
     try:
         original_pid = fragment["Dynamic"]["s3_object_key"].split(".")[0]
         fragment_id = fragment["Internal"]["FragmentId"]

--- a/app/core/events_parser.py
+++ b/app/core/events_parser.py
@@ -21,7 +21,7 @@ XPATHS = {
     "event_detail": "./p:eventDetail",
     "event_id": "./p:eventIdentifier[p:eventIdentifierType='MEDIAHAVEN_EVENT']/p:eventIdentifierValue",
     "event_outcome": "./p:eventOutcomeInformation/p:eventOutcome",
-    "fragment_id": "./p:linkingObjectIdentifier[p:linkingObjectIdentifierType='MEDIAHAVEN_ID']/p:linkingObjectIdentifierValue",
+    "mediahaven_id": "./p:linkingObjectIdentifier[p:linkingObjectIdentifierType='MEDIAHAVEN_ID']/p:linkingObjectIdentifierValue",
     "external_id": "./p:linkingObjectIdentifier[p:linkingObjectIdentifierType='EXTERNAL_ID']/p:linkingObjectIdentifierValue",
 }
 
@@ -47,7 +47,7 @@ def parse_premis_event(element):
         "event_detail": _get_xpath_from_event(element, XPATHS["event_detail"]),
         "event_id": _get_xpath_from_event(element, XPATHS["event_id"]),
         "event_outcome": _get_xpath_from_event(element, XPATHS["event_outcome"]),
-        "fragment_id": _get_xpath_from_event(element, XPATHS["fragment_id"]),
+        "mediahaven_id": _get_xpath_from_event(element, XPATHS["mediahaven_id"]),
         "external_id": _get_xpath_from_event(element, XPATHS["external_id"]),
         "is_valid": _is_valid(_get_xpath_from_event(element, XPATHS["event_type"])),
         "has_valid_outcome": _has_valid_outcome(

--- a/app/models/premis_events.py
+++ b/app/models/premis_events.py
@@ -9,7 +9,7 @@ class PremisEvent(BaseModel):
     event_detail: str
     event_id: str
     event_outcome: str
-    fragment_id: str
+    mediahaven_id: str
     external_id: str
     is_valid: bool
     has_valid_outcome: bool

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -7,19 +7,20 @@ from tests.resources import (
     fragment_info,
     query_result_single_result,
     single_premis_event,
+    sidecar
 )
 
 
 def test_handle_events(client: TestClient, mocker: MockerFixture) -> None:
-    mocker.patch(
+    get_fragment_mock = mocker.patch(
         "app.services.mediahaven.MediahavenService.get_fragment",
         return_value=json.loads(fragment_info.decode()),
     )
-    mocker.patch(
+    query_mock = mocker.patch(
         "app.services.mediahaven.MediahavenService.query",
         return_value=query_result_single_result,
     )
-    mocker.patch(
+    update_metadata_mock = mocker.patch(
         "app.services.mediahaven.MediahavenService.update_metadata",
         return_value=True,
     )
@@ -29,6 +30,9 @@ def test_handle_events(client: TestClient, mocker: MockerFixture) -> None:
         data=single_premis_event,
     )
 
+    get_fragment_mock.assert_called_once_with("a1b2c3")
+    query_mock.assert_called_once_with([("PID", "s3_filename")])
+    update_metadata_mock.assert_called_once_with("123456789101112131415161718192021222324252627282930313233343536373839404142434445464748495051525", sidecar)
     assert response.status_code == 202
     content = response.json()
     assert "Updating" in content["message"]

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -6,8 +6,8 @@ from pytest_mock import MockerFixture
 from tests.resources import (
     fragment_info,
     query_result_single_result,
+    sidecar,
     single_premis_event,
-    sidecar
 )
 
 
@@ -32,7 +32,10 @@ def test_handle_events(client: TestClient, mocker: MockerFixture) -> None:
 
     get_fragment_mock.assert_called_once_with("a1b2c3")
     query_mock.assert_called_once_with([("PID", "s3_filename")])
-    update_metadata_mock.assert_called_once_with("123456789101112131415161718192021222324252627282930313233343536373839404142434445464748495051525", sidecar)
+    update_metadata_mock.assert_called_once_with(
+        "123456789101112131415161718192021222324252627282930313233343536373839404142434445464748495051525",
+        sidecar,
+    )
     assert response.status_code == 202
     content = response.json()
     assert "Updating" in content["message"]

--- a/tests/core/test_events_parser.py
+++ b/tests/core/test_events_parser.py
@@ -34,7 +34,7 @@ def test_single_event(resource, event_type):
     assert len(p["events"]) == 1
     assert p["events"][0]["event_id"] == "111"
     assert p["events"][0]["event_detail"] == "Ionic Defibulizer"
-    assert p["events"][0]["fragment_id"] == "a1b2c3"
+    assert p["events"][0]["mediahaven_id"] == "a1b2c3"
     assert p["events"][0]["event_type"] == event_type
     assert p["events"][0]["event_outcome"] == "OK"
     assert p["events"][0]["event_datetime"] == "2019-03-30T05:28:40Z"
@@ -53,7 +53,7 @@ def test_multi_event():
     assert len(p["events"]) == 2
     assert p["events"][0]["event_id"] == "333"
     assert p["events"][0]["event_detail"] == "Ionic Defibulizer"
-    assert p["events"][0]["fragment_id"] == "d4e5f6"
+    assert p["events"][0]["mediahaven_id"] == "d4e5f6"
     assert p["events"][0]["event_type"] == "FLOW.ARCHIVED"
     assert p["events"][0]["event_outcome"] == "OK"
     assert p["events"][0]["event_datetime"] == "2019-03-30T05:28:40Z"
@@ -61,7 +61,7 @@ def test_multi_event():
     assert p["events"][0]["has_valid_outcome"]
     assert p["events"][1]["event_id"] == "444"
     assert p["events"][1]["event_detail"] == "Ionic Defibulizer 2"
-    assert p["events"][1]["fragment_id"] == "g7h8j9"
+    assert p["events"][1]["mediahaven_id"] == "g7h8j9"
     assert p["events"][1]["event_type"] == "RECORDS.FLOW.ARCHIVED"
     assert p["events"][1]["event_outcome"] == "OK"
     assert p["events"][1]["event_datetime"] == "2019-03-30T05:28:40Z"


### PR DESCRIPTION
fragment_id variable has been renamed to mediahaven_id in places where it can contain either a fragment id or a media object id. The fragment_id variable should now always point to a real fragment id.

Tests have been extended to test the parameters with which the mediahaven mock functions haven been called.