### PR TITLE
DEV-1558 Add `is_versie_van` to `dc_relations` in new metadata.

### DIFF
--- a/app/resources/transform.xslt
+++ b/app/resources/transform.xslt
@@ -32,6 +32,9 @@
                 <is_verwant_aan>
                     <xsl:value-of select="//mhs:Dynamic/PID"/>
                 </is_verwant_aan>
+                <is_versie_van>
+                    <xsl:value-of select="//mhs:Administrative/mh:ExternalId"/>
+                </is_versie_van>
             </dc_relations>
         </xsl:copy>
     </xsl:template>

--- a/tests/resources/mh_api_responses/query_result_single_result.xml
+++ b/tests/resources/mh_api_responses/query_result_single_result.xml
@@ -18,7 +18,7 @@
             <mhs:Administrative>
                 <mh:OrganisationName>testbeeld</mh:OrganisationName>
                 <mh:LastModifiedDate>2021-02-17T10:21:19Z</mh:LastModifiedDate>
-                <mh:ExternalId>ms3jx0t169</mh:ExternalId>
+                <mh:ExternalId>EXTERNALID_OF_ORIGINAL_FRAGMENT</mh:ExternalId>
                 <mh:ArchiveDate>2021:02:16 08:30:17</mh:ArchiveDate>
                 <mh:Type>videofragment</mh:Type>
                 <mh:DepartmentName>testbeeld</mh:DepartmentName>

--- a/tests/resources/transformation_results/sidecar.xml
+++ b/tests/resources/transformation_results/sidecar.xml
@@ -46,6 +46,7 @@
     <Original_CP_id>OR-xxxxxxx</Original_CP_id>
     <dc_relations type="list">
       <is_verwant_aan>PID_OF_ORIGINAL_FRAGMENT</is_verwant_aan>
+      <is_versie_van>EXTERNALID_OF_ORIGINAL_FRAGMENT</is_versie_van>
     </dc_relations>
   </mhs:Dynamic>
 </mhs:Sidecar>


### PR DESCRIPTION
`is_versie_van` should point to the external Id of the original Item.