### PR TITLE
DEV-1552 Remove default uvicorn log handlers.

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,3 +26,4 @@ if __name__ == "__main__":
             logger.handlers = []
 
     server.run()
+    

--- a/main.py
+++ b/main.py
@@ -1,4 +1,28 @@
-import uvicorn
+import logging
+
+from uvicorn import Config, Server
+
+from viaa.configuration import ConfigParser
+
+cfg_log_level = ConfigParser().chassis_cfg["logging"]["level"]
+# Uvicorn expects lowercase string or integer as the logging level.
+LOG_LEVEL = cfg_log_level.lower() if isinstance(cfg_log_level, str) else cfg_log_level
 
 if __name__ == "__main__":
-    uvicorn.run("app.app:app", host="0.0.0.0", port=8080)
+    server = Server(
+        Config(
+            "app.app:app",
+            host="0.0.0.0",
+            port=8080,
+            access_log=False,
+            log_level=LOG_LEVEL,
+        ),
+    )
+
+    # Remove the Uvicorn logging handlers, as our own loggers log in a JSON format.
+    # Just remove them all although the access handler is already removed by "access_log=False".
+    for name, logger in logging.root.manager.loggerDict.items():
+        if name.startswith("uvicorn"):
+            logger.handlers = []
+
+    server.run()


### PR DESCRIPTION
Logs now get printed using the chassis log handler to make it JSON.
Access logs are disabled to remove healthcheck spam in the logs.