### PR TITLE
DEV-1517 Handle multiple items for PID.

### DIFF
--- a/app/services/mediahaven.py
+++ b/app/services/mediahaven.py
@@ -64,7 +64,7 @@ class MediahavenService:
     def query(self, query_key_values) -> bytes:
         headers: Dict[str, str] = {
             "Authorization": f"Bearer {self.token_info['access_token']}",
-            "Accept": "application/vnd.mediahaven.v2+xml",
+            "Accept": "application/vnd.mediahaven.v2+json",
         }
 
         # Construct URL query parameters as "+(k1:v1) +(k2:v2) +(k3:v3) ..."
@@ -90,15 +90,15 @@ class MediahavenService:
         # If there is an HTTP error, raise it
         response.raise_for_status()
 
-        return response.content
+        return response.json()
 
     @__authenticate
-    def get_fragment(self, fragment_id: str) -> dict:
+    def get_fragment(self, fragment_id: str, content_type: str = "json") -> dict:
         url: str = f"{self.cfg['mediahaven']['host']}/media/{fragment_id}"
 
         headers: dict = {
             "Authorization": f"Bearer {self.token_info['access_token']}",
-            "Accept": "application/vnd.mediahaven.v2+json",
+            "Accept": f"application/vnd.mediahaven.v2+{content_type}",
         }
 
         response = requests.get(
@@ -113,7 +113,10 @@ class MediahavenService:
         if response.status_code in (400, 404):
             raise MediaObjectNotFoundException(response.json())
 
-        return response.json()
+        if content_type == "json":
+            return response.json()
+        else:
+            return response.content
 
     @__authenticate
     def update_metadata(self, fragment_id: str, sidecar: bytes) -> bool:

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -3,10 +3,13 @@ import json
 import pytest
 from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
+from unittest.mock import call
 
 from tests.resources import (
-    fragment_info,
-    query_result_single_result,
+    fragment_info_json,
+    fragment_info_xml,
+    query_result_single_result_json,
+    query_result_multiple_results_json,
     sidecar,
     single_premis_event,
     single_premis_event_empty_detail,
@@ -22,13 +25,20 @@ from tests.resources import (
     ],
 )
 def test_handle_events(client: TestClient, mocker: MockerFixture, resource) -> None:
+    def get_fragment_side_effect(fragment_id, content_type = "json"):
+        if content_type == "json":
+            return json.loads(fragment_info_json.decode())
+        if content_type == "xml":
+            return fragment_info_xml
+        return ""
+
     get_fragment_mock = mocker.patch(
         "app.services.mediahaven.MediahavenService.get_fragment",
-        return_value=json.loads(fragment_info.decode()),
+        side_effect=get_fragment_side_effect,
     )
     query_mock = mocker.patch(
         "app.services.mediahaven.MediahavenService.query",
-        return_value=query_result_single_result,
+        return_value=json.loads(query_result_single_result_json),
     )
     update_metadata_mock = mocker.patch(
         "app.services.mediahaven.MediahavenService.update_metadata",
@@ -39,8 +49,65 @@ def test_handle_events(client: TestClient, mocker: MockerFixture, resource) -> N
         "/event/",
         data=resource,
     )
+    get_fragment_mock.assert_has_calls(
+        [
+            call("a1b2c3"),
+            call(
+                "123456789101112131415161718192021222324252627282930313233343536373839404142434445464748495051525",
+                "xml",
+            ),
+        ]
+    )
+    query_mock.assert_called_once_with([("PID", "s3_filename")])
+    update_metadata_mock.assert_called_once_with(
+        "123456789101112131415161718192021222324252627282930313233343536373839404142434445464748495051525",
+        sidecar,
+    )
+    assert response.status_code == 202
+    content = response.json()
+    assert "Updating 1" in content["message"]
 
-    get_fragment_mock.assert_called_once_with("a1b2c3")
+@pytest.mark.parametrize(
+    "resource",
+    [
+        single_premis_event,
+        single_premis_event_empty_detail,
+    ],
+)
+def test_handle_events_multiple_results_for_pid(client: TestClient, mocker: MockerFixture, resource) -> None:
+    def get_fragment_side_effect(fragment_id, content_type = "json"):
+        if content_type == "json":
+            return json.loads(fragment_info_json.decode())
+        if content_type == "xml":
+            return fragment_info_xml
+        return ""
+
+    get_fragment_mock = mocker.patch(
+        "app.services.mediahaven.MediahavenService.get_fragment",
+        side_effect=get_fragment_side_effect,
+    )
+    query_mock = mocker.patch(
+        "app.services.mediahaven.MediahavenService.query",
+        return_value=json.loads(query_result_multiple_results_json),
+    )
+    update_metadata_mock = mocker.patch(
+        "app.services.mediahaven.MediahavenService.update_metadata",
+        return_value=True,
+    )
+
+    response = client.post(
+        "/event/",
+        data=resource,
+    )
+    get_fragment_mock.assert_has_calls(
+        [
+            call("a1b2c3"),
+            call(
+                "123456789101112131415161718192021222324252627282930313233343536373839404142434445464748495051525",
+                "xml",
+            ),
+        ]
+    )
     query_mock.assert_called_once_with([("PID", "s3_filename")])
     update_metadata_mock.assert_called_once_with(
         "123456789101112131415161718192021222324252627282930313233343536373839404142434445464748495051525",
@@ -54,11 +121,11 @@ def test_handle_events(client: TestClient, mocker: MockerFixture, resource) -> N
 def test_handle_NOK_events(client: TestClient, mocker: MockerFixture) -> None:
     get_fragment_mock = mocker.patch(
         "app.services.mediahaven.MediahavenService.get_fragment",
-        return_value=json.loads(fragment_info.decode()),
+        return_value=json.loads(fragment_info_json.decode()),
     )
     query_mock = mocker.patch(
         "app.services.mediahaven.MediahavenService.query",
-        return_value=query_result_single_result,
+        return_value=query_result_single_result_json,
     )
     update_metadata_mock = mocker.patch(
         "app.services.mediahaven.MediahavenService.update_metadata",

--- a/tests/core/test_xml_transformer.py
+++ b/tests/core/test_xml_transformer.py
@@ -1,11 +1,11 @@
 from app.core.xml_transformer import transform_mh_result_to_sidecar
-from tests.resources import query_result_single_result, sidecar
+from tests.resources import fragment_info_xml, sidecar
 
 
 def test_handle_events() -> None:
     # ARRANGE
 
     # ACT
-    transformed = transform_mh_result_to_sidecar(query_result_single_result)
+    transformed = transform_mh_result_to_sidecar(fragment_info_xml)
     # ASSERT
     assert transformed == sidecar

--- a/tests/resources/__init__.py
+++ b/tests/resources/__init__.py
@@ -2,10 +2,14 @@
 # -*- coding: utf-8 -*-
 
 from .mh_api_responses import (
-    fragment_info,
-    query_result_multiple_results,
-    query_result_no_result,
-    query_result_single_result,
+    fragment_info_json,
+    fragment_info_xml,
+    query_result_multiple_results_json,
+    query_result_multiple_results_xml,
+    query_result_no_result_json,
+    query_result_no_result_xml,
+    query_result_single_result_json,
+    query_result_single_result_xml,
 )
 from .premis_events import (
     invalid_premis_event,

--- a/tests/resources/mh_api_responses.py
+++ b/tests/resources/mh_api_responses.py
@@ -12,7 +12,11 @@ def _load_resource(filename):
     return contents
 
 
-fragment_info = _load_resource("fragment_info.json")
-query_result_multiple_results = _load_resource("query_result_multiple_results.xml")
-query_result_no_result = _load_resource("query_result_no_result.xml")
-query_result_single_result = _load_resource("query_result_single_result.xml")
+fragment_info_json = _load_resource("fragment_info.json")
+fragment_info_xml = _load_resource("fragment_info.xml")
+query_result_multiple_results_json = _load_resource("query_result_multiple_results.json")
+query_result_multiple_results_xml = _load_resource("query_result_multiple_results.xml")
+query_result_no_result_json = _load_resource("query_result_no_result.json")
+query_result_no_result_xml = _load_resource("query_result_no_result.xml")
+query_result_single_result_json = _load_resource("query_result_single_result.json")
+query_result_single_result_xml = _load_resource("query_result_single_result.xml")

--- a/tests/resources/mh_api_responses/fragment_info.xml
+++ b/tests/resources/mh_api_responses/fragment_info.xml
@@ -1,8 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<root>
-    <TotalNrOfResults>1</TotalNrOfResults>
-    <StartIndex>0</StartIndex>
-    <MediaDataList>
 <mhs:Sidecar xmlns:mh="https://zeticon.mediahaven.com/metadata/20.3/mh/"
     xmlns:mhs="https://zeticon.mediahaven.com/metadata/20.3/mhs/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="20.3" xsi:schemaLocation="https://zeticon.mediahaven.com/metadata/20.3/mhs/ https://zeticon.mediahaven.com/metadata/20.3/mhs.xsd https://zeticon.mediahaven.com/metadata/20.3/mh/ https://zeticon.mediahaven.com/metadata/20.3/mh.xsd">
@@ -187,5 +182,3 @@
         <IsExportable>true</IsExportable>
     </Context>
 </mhs:Sidecar>
-    </MediaDataList>
-</root>

--- a/tests/resources/mh_api_responses/query_result_multiple_results.json
+++ b/tests/resources/mh_api_responses/query_result_multiple_results.json
@@ -1,0 +1,32 @@
+{
+  "TotalNrOfResults": 2,
+  "StartIndex": 0,
+  "MediaDataList": [
+    {
+      "Administrative": {},
+      "Internal": {
+        "IsFragment": false,
+        "FragmentId": "123456789101112131415161718192021222324252627282930313233343536373839404142434445464748495051525"
+      },
+      "Dynamic": {},
+      "Technical": {},
+      "RightsManagement": {},
+      "Descriptive": {},
+      "Structural": {},
+      "Context": {}
+    },
+    {
+      "Administrative": {},
+      "Internal": {
+        "IsFragment": true,
+        "FragmentId": "1234567891011121314151617181920212223242526272829303132333435363dfe24b95373a4ca6b00ebfee3447bd75"
+      },
+      "Dynamic": {},
+      "Technical": {},
+      "RightsManagement": {},
+      "Descriptive": {},
+      "Structural": {},
+      "Context": {}
+    }
+  ]
+}

--- a/tests/resources/mh_api_responses/query_result_no_result.json
+++ b/tests/resources/mh_api_responses/query_result_no_result.json
@@ -1,0 +1,5 @@
+{
+    "TotalNrOfResults": 0,
+    "StartIndex": 0,
+    "MediaDataList": []
+}

--- a/tests/resources/mh_api_responses/query_result_single_result.json
+++ b/tests/resources/mh_api_responses/query_result_single_result.json
@@ -1,0 +1,19 @@
+{
+    "TotalNrOfResults": 1,
+    "StartIndex": 0,
+    "MediaDataList": [
+        {
+            "Administrative": {},
+            "Internal": {
+                "MediaObjectId": "1234567891011121314151617181920212223242526272829303132333435363",
+                "FragmentId": "123456789101112131415161718192021222324252627282930313233343536373839404142434445464748495051525"
+            },
+            "Dynamic": {},
+            "Technical": {},
+            "RightsManagement": {},
+            "Structural": {},
+            "Descriptive": {},
+            "Context": {}
+        }
+    ]
+}

--- a/tests/resources/transformation_results/sidecar.xml
+++ b/tests/resources/transformation_results/sidecar.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='UTF-8'?>
 <mhs:Sidecar xmlns:mhs="https://zeticon.mediahaven.com/metadata/20.3/mhs/" xmlns:mh="https://zeticon.mediahaven.com/metadata/20.3/mh/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="20.3">
   <mhs:Descriptive>
     <mh:Title>Something</mh:Title>
@@ -6,30 +6,30 @@
   </mhs:Descriptive>
   <mhs:Dynamic>
     <dc_identifier_localids>
-                    <MEDIA_ID>MEDIA_ID</MEDIA_ID>
-                </dc_identifier_localids>
+            <MEDIA_ID>MEDIA_ID</MEDIA_ID>
+        </dc_identifier_localids>
     <dc_titles>
-                    <alternatief>Feed</alternatief>
-                    <serie>Sportarchief</serie>
-                </dc_titles>
+            <alternatief>Feed</alternatief>
+            <serie>Sportarchief</serie>
+        </dc_titles>
     <dc_contributors>
-                    <archivaris>Rudolf</archivaris>
-                </dc_contributors>
+            <archivaris>Rudolf</archivaris>
+        </dc_contributors>
     <dc_publishers>
-                    <Distributeur>Ten</Distributeur>
-                </dc_publishers>
+            <Distributeur>Ten</Distributeur>
+        </dc_publishers>
     <dc_subjects>
-                    <Trefwoord>VOETBAL</Trefwoord>
-                    <Trefwoord>COMPETITIE</Trefwoord>
-                    <Trefwoord>SPANJE</Trefwoord>
-                    <Trefwoord>REAL MADRID</Trefwoord>
-                    <Trefwoord>VALENCIA</Trefwoord>
-                    <Trefwoord>BENZEMA KARIM</Trefwoord>
-                    <Trefwoord>KROOS TONI</Trefwoord>
-                </dc_subjects>
+            <Trefwoord>VOETBAL</Trefwoord>
+            <Trefwoord>COMPETITIE</Trefwoord>
+            <Trefwoord>SPANJE</Trefwoord>
+            <Trefwoord>REAL MADRID</Trefwoord>
+            <Trefwoord>VALENCIA</Trefwoord>
+            <Trefwoord>BENZEMA KARIM</Trefwoord>
+            <Trefwoord>KROOS TONI</Trefwoord>
+        </dc_subjects>
     <dc_rights_rightsHolders>
-                    <Licentiehouder/>
-                </dc_rights_rightsHolders>
+            <Licentiehouder/>
+        </dc_rights_rightsHolders>
     <dc_source>s3_filename_origineel.mxf</dc_source>
     <ie_type>video</ie_type>
     <type_viaa>video</type_viaa>

--- a/tests/resources/transformation_results/sidecar.xml
+++ b/tests/resources/transformation_results/sidecar.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <mhs:Sidecar xmlns:mhs="https://zeticon.mediahaven.com/metadata/20.3/mhs/" xmlns:mh="https://zeticon.mediahaven.com/metadata/20.3/mh/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="20.3">
   <mhs:Descriptive>
     <mh:Title>Something</mh:Title>


### PR DESCRIPTION
In the old strata flow multiple fragments where created on an item. These fragments all have the same PID, when querying mediahaven we have to take the one that is not a fragment to copy the metadata from.