### PR TITLE
DEV-1665 Extract pid from s3_object_key.

### DIFF
--- a/app/core/event_handler.py
+++ b/app/core/event_handler.py
@@ -81,7 +81,7 @@ async def handle_event(premis_event: PremisEvent) -> None:
     fragment_id = fragment["Internal"]["FragmentId"]
 
     try:
-        original_pid = fragment["Dynamic"]["s3_object_key"].split(".")[0]
+        original_pid = fragment["Dynamic"]["s3_object_key"][0:10]
     except KeyError as e:
         log.warning(
             f"{e} is missing on the testbeeld item.",

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -58,7 +58,7 @@ def test_handle_events(client: TestClient, mocker: MockerFixture, resource) -> N
             ),
         ]
     )
-    query_mock.assert_called_once_with([("PID", "s3_filename")])
+    query_mock.assert_called_once_with([("PID", "s3filename")])
     update_metadata_mock.assert_called_once_with(
         "123456789101112131415161718192021222324252627282930313233343536373839404142434445464748495051525",
         sidecar,
@@ -108,7 +108,7 @@ def test_handle_events_multiple_results_for_pid(client: TestClient, mocker: Mock
             ),
         ]
     )
-    query_mock.assert_called_once_with([("PID", "s3_filename")])
+    query_mock.assert_called_once_with([("PID", "s3filename")])
     update_metadata_mock.assert_called_once_with(
         "123456789101112131415161718192021222324252627282930313233343536373839404142434445464748495051525",
         sidecar,

--- a/tests/resources/mh_api_responses/fragment_info.json
+++ b/tests/resources/mh_api_responses/fragment_info.json
@@ -70,7 +70,7 @@
         "CP": "vrt",
         "object_use": "archive_master",
         "s3_domain": "s3-qas.viaa.be",
-        "s3_object_key": "s3_filename.mxf",
+        "s3_object_key": "s3filename.mxf",
         "ie_type": "n/a",
         "CP_id": "OR-xxxxxx",
         "md5_viaa": "571fbacd0d2e57882cf4bf23315e1653",


### PR DESCRIPTION
Take the first 10 characters instead of splitting to remove the extension.
Items with a sequence number after the orignal pid are now supported.