### PR TITLE
DEV-1712 Fix query for items with >25 fragments.

### DIFF
--- a/app/services/mediahaven.py
+++ b/app/services/mediahaven.py
@@ -72,7 +72,10 @@ class MediahavenService:
 
         params_dict: Dict[str, str] = {
             "q": query,
+            "nrOfResults": 1000,
         }
+
+        print(params_dict)
         # Encode the spaces in the query parameters as %20 and not +
         params = urllib.parse.urlencode(params_dict, quote_via=urllib.parse.quote)
 


### PR DESCRIPTION
This will break for items with >1000 fragments, but this should not happen as there are currently no items with > 1000 fragments and no new items are ingested which create a lot of fragments. :crossed_fingers: 