### PR TITLE
DEV-1712 Change nrOfResults to 1000.

### DIFF
--- a/app/services/mediahaven.py
+++ b/app/services/mediahaven.py
@@ -72,6 +72,7 @@ class MediahavenService:
 
         params_dict: Dict[str, str] = {
             "q": query,
+            "nrOfResults": 1000,
         }
         # Encode the spaces in the query parameters as %20 and not +
         params = urllib.parse.urlencode(params_dict, quote_via=urllib.parse.quote)


### PR DESCRIPTION
This still breaks the integration for items with >1000 fragments, but no such items exist at the moment and we don't make new items with strata fragments. :crossed_fingers: 