### PR TITLE
DEV-1847 Support original PIDs with more then 10 chars

### DIFF
--- a/app/core/event_handler.py
+++ b/app/core/event_handler.py
@@ -31,6 +31,35 @@ def determine_original_pid(s3_object_key: str) -> Union[str, None]:
     return None
 
 
+def get_original_pid_from_fragment(fragment: dict) -> str:
+    """Retrieve the `s3_object_key` and determine the original pid from the
+    whole of the fragment.
+
+    Here, we can return both a KeyError (if the `s3_object_key` would not be
+    present) or a ValueError (if the export name and thus the original pid is
+    likely wrong).
+
+    Args:
+        The MediaHaven fragment/record as dict
+
+    Returns:
+        The original PID as a string, or KeyError/ValueError
+
+    Raises:
+        KeyError: If `s3_object_key` is absent.
+        ValueError: If the original pid has a wrong format.
+    """
+    # This will raise a KeyError if `s3_object_key` is not present
+    s3_object_key = fragment["Dynamic"]["s3_object_key"]
+    #
+    original_pid = determine_original_pid(s3_object_key)
+    # If we get None back, raise a ValueError
+    if not original_pid:
+        raise ValueError(f"Could not determine valid pid from \"{s3_object_key}\"")
+    # Else, return the string (original_pid)
+    return original_pid
+
+
 def determine_original_item(mediahaven_result: dict) -> str:
     """From a MediaHaven result list, determine which of the items carries the
     original metadata.

--- a/app/core/event_handler.py
+++ b/app/core/event_handler.py
@@ -62,7 +62,7 @@ def get_original_pid_from_fragment(fragment: dict) -> str:
     original_pid = determine_original_pid(s3_object_key)
     # If we get None back, raise a ValueError
     if not original_pid:
-        raise ValueError(f"Could not determine valid pid from \"{s3_object_key}\"")
+        raise ValueError(f'Could not determine valid pid from "{s3_object_key}"')
     # Else, return the string (original_pid)
     return original_pid
 

--- a/app/core/event_handler.py
+++ b/app/core/event_handler.py
@@ -131,10 +131,16 @@ async def handle_event(premis_event: PremisEvent) -> None:
     fragment_id = fragment["Internal"]["FragmentId"]
 
     try:
-        original_pid = fragment["Dynamic"]["s3_object_key"][0:10]
+        original_pid = get_original_pid_from_fragment(fragment)
     except KeyError as e:
         log.warning(
             f"{e} is missing on the testbeeld item.",
+            mediahaven_id=premis_event.mediahaven_id,
+        )
+        return
+    except ValueError as e:
+        log.warning(
+            f"ValueError: {e}",
             mediahaven_id=premis_event.mediahaven_id,
         )
         return

--- a/app/core/event_handler.py
+++ b/app/core/event_handler.py
@@ -23,8 +23,15 @@ def determine_original_pid(s3_object_key: str) -> Union[str, None]:
           variant (eg. `mezanine`),
     As to be not too restrictive, we allow for some variation in the part that
     follows the underscore. The `pid` itself, however, should not deviate from
-    a 10 char lowercase alphanum string."""
-    pattern = re.compile("^([a-z0-9]{10})_?([a-zA-Z]{0,12})")
+    a 10 char lowercase alphanum string.
+
+    Args:
+        The `s3_object_key` (or export name) as str
+
+    Returns:
+        The likely original PID as a string, or None
+    """
+    pattern = re.compile("^[a-z0-9]{10}_?[a-zA-Z]{0,12}")
     match_obj = pattern.match(s3_object_key)
     if match_obj:
         return match_obj.group()

--- a/tests/core/test_events_handler.py
+++ b/tests/core/test_events_handler.py
@@ -2,9 +2,13 @@
 # -*- coding: utf-8 -*-
 
 import json
+from typing import Union
 import pytest
 
-from app.core.event_handler import determine_original_item
+from app.core.event_handler import (
+    determine_original_item,
+    determine_original_pid
+)
 from tests.resources import (
     fragment_info_json,
     query_result_multiple_results_json_3,
@@ -12,6 +16,40 @@ from tests.resources import (
     query_result_no_result_json,
     query_result_single_result_json
 )
+
+test_data_original_pid = [
+    # Regular pid
+    ("639k36mb0j.mp4", "639k36mb0j"),
+    # Regular pid with `mezanine`
+    ("vx05x2t51z_mezanine.mp4", "vx05x2t51z_mezanine"),
+    # Regular pid, exported more than once
+    ("125q82jj84-1.mp4", "125q82jj84"),
+    # Other valid forms
+    ("930ns3cj88.mxf.zip", "930ns3cj88"),
+    ("w37kq0rq6r_open.srt", "w37kq0rq6r_open"),
+    ("p55dc0sg4r_wav.mp4", "p55dc0sg4r_wav"),
+    ("p55dc0sg4r_wavelength.extension", "p55dc0sg4r_wavelength"),
+    ("h98z89692m_twelvecharst-2.mp4", "h98z89692m_twelvecharst"),
+    ("h98z89692m_mezanine-2.mp4", "h98z89692m_mezanine"),
+    ("h98z89692m_mezzanine-2.mp4", "h98z89692m_mezzanine"),
+    ("8911p0vh59_metadata.ebu", "8911p0vh59_metadata"),
+    # Invalid export names
+    ("2000-1.mp4", None),
+    ("EXPERT_Voornaam Van Achternaam- Programma Naam.mp4", None),
+    ("Essence pid tq5r813p56.mp4", None),
+    ("een_random_string_met.extensie", None),
+    ("TER ZAKE.mp4", None),
+    # Typo in export name (starts with capital letter)
+    ("Eb56d24nz3c.mp4", None),
+]
+
+
+@pytest.mark.parametrize("s3_object_key,expected_value", test_data_original_pid)
+def test_determine_original_pid(s3_object_key: str, expected_value: Union[str, None]):
+    # Act
+    original_pid = determine_original_pid(s3_object_key)
+    # Assert
+    assert original_pid == expected_value
 
 
 def test_determine_original_item_single_item():

--- a/tests/core/test_events_handler.py
+++ b/tests/core/test_events_handler.py
@@ -7,7 +7,8 @@ import pytest
 
 from app.core.event_handler import (
     determine_original_item,
-    determine_original_pid
+    determine_original_pid,
+    get_original_pid_from_fragment
 )
 from tests.resources import (
     fragment_info_json,
@@ -51,6 +52,28 @@ def test_determine_original_pid(s3_object_key: str, expected_value: Union[str, N
     # Assert
     assert original_pid == expected_value
 
+def test_get_original_pid_from_fragment_correct():
+    # Arrange
+    fragment_dict = json.loads(fragment_info_json.decode())
+    # Act
+    original_pid = get_original_pid_from_fragment(fragment_dict)
+    # Assert
+    assert original_pid == "s3filename"
+
+def test_get_original_pid_from_fragment_KeyError():
+    # Arrange
+    fragment_dict = json.loads(fragment_info_json.decode())
+    del fragment_dict["Dynamic"]["s3_object_key"]
+    # Act & assert
+    with pytest.raises(KeyError):
+        _ = get_original_pid_from_fragment(fragment_dict)
+def test_get_original_pid_from_fragment_ValueError():
+    # Arrange
+    fragment_dict = json.loads(fragment_info_json.decode())
+    fragment_dict["Dynamic"]["s3_object_key"] = "a wrong export name"
+    # Act & assert
+    with pytest.raises(ValueError):
+        _ = get_original_pid_from_fragment(fragment_dict)
 
 def test_determine_original_item_single_item():
     # Arrange

--- a/tests/core/test_events_handler.py
+++ b/tests/core/test_events_handler.py
@@ -67,6 +67,7 @@ def test_get_original_pid_from_fragment_KeyError():
     # Act & assert
     with pytest.raises(KeyError):
         _ = get_original_pid_from_fragment(fragment_dict)
+
 def test_get_original_pid_from_fragment_ValueError():
     # Arrange
     fragment_dict = json.loads(fragment_info_json.decode())


### PR DESCRIPTION
A wider variety of different "forms of pid's" are used than can be captured by merely the first 10-chars of the object key. Pid's with `mezzanine` as a suffix, for example, exist. These changes allow for these pid's to be correctly identified.