### PR TITLE
DEV-2727 Change MH namespaces in XSLT

### DIFF
--- a/app/resources/transform.xslt
+++ b/app/resources/transform.xslt
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet version="2.0"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:mh="https://zeticon.mediahaven.com/metadata/24.1/mh/"
-    xmlns:mhs="https://zeticon.mediahaven.com/metadata/24.1/mhs/"
+    xmlns:mh="https://zeticon.mediahaven.com/metadata/25.1/mh/"
+    xmlns:mhs="https://zeticon.mediahaven.com/metadata/25.1/mhs/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <xsl:output method="xml" encoding="UTF-8" byte-order-mark="no" indent="yes" />
     <xsl:template match="/">
-        <mhs:Sidecar xmlns:mhs="https://zeticon.mediahaven.com/metadata/24.1/mhs/"
-            xmlns:mh="https://zeticon.mediahaven.com/metadata/24.1/mh/" version="24.1">
+        <mhs:Sidecar xmlns:mhs="https://zeticon.mediahaven.com/metadata/25.1/mhs/"
+            xmlns:mh="https://zeticon.mediahaven.com/metadata/25.1/mh/" version="25.1">
             <mhs:Descriptive>
                 <xsl:apply-templates select="//mhs:Descriptive/mh:Title" />
                 <xsl:apply-templates select="//mhs:Descriptive/mh:Description" />

--- a/tests/resources/mh_api_responses/fragment_info.xml
+++ b/tests/resources/mh_api_responses/fragment_info.xml
@@ -1,6 +1,6 @@
-<mhs:Sidecar xmlns:mh="https://zeticon.mediahaven.com/metadata/24.1/mh/"
-    xmlns:mhs="https://zeticon.mediahaven.com/metadata/24.1/mhs/"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="24.1" xsi:schemaLocation="https://zeticon.mediahaven.com/metadata/24.1/mhs/ https://zeticon.mediahaven.com/metadata/24.1/mhs.xsd https://zeticon.mediahaven.com/metadata/24.1/mh/ https://zeticon.mediahaven.com/metadata/24.1/mh.xsd">
+<mhs:Sidecar xmlns:mh="https://zeticon.mediahaven.com/metadata/25.1/mh/"
+    xmlns:mhs="https://zeticon.mediahaven.com/metadata/25.1/mhs/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="25.1" xsi:schemaLocation="https://zeticon.mediahaven.com/metadata/25.1/mhs/ https://zeticon.mediahaven.com/metadata/25.1/mhs.xsd https://zeticon.mediahaven.com/metadata/25.1/mh/ https://zeticon.mediahaven.com/metadata/25.1/mh.xsd">
     <mhs:Descriptive>
         <mh:Title>Something</mh:Title>
         <mh:Description>Something descriptive</mh:Description>

--- a/tests/resources/mh_api_responses/query_result_multiple_results.xml
+++ b/tests/resources/mh_api_responses/query_result_multiple_results.xml
@@ -3,13 +3,13 @@
     <TotalNrOfResults>2</TotalNrOfResults>
     <StartIndex>0</StartIndex>
     <Results>
-        <mhs:Sidecar xmlns:mh="https://zeticon.mediahaven.com/metadata/24.1/mh/"
-            xmlns:mhs="https://zeticon.mediahaven.com/metadata/24.1/mhs/"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="24.1" xsi:schemaLocation="https://zeticon.mediahaven.com/metadata/24.1/mhs/ https://zeticon.mediahaven.com/metadata/24.1/mhs.xsd https://zeticon.mediahaven.com/metadata/24.1/mh/ https://zeticon.mediahaven.com/metadata/24.1/mh.xsd">
+        <mhs:Sidecar xmlns:mh="https://zeticon.mediahaven.com/metadata/25.1/mh/"
+            xmlns:mhs="https://zeticon.mediahaven.com/metadata/25.1/mhs/"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="25.1" xsi:schemaLocation="https://zeticon.mediahaven.com/metadata/25.1/mhs/ https://zeticon.mediahaven.com/metadata/25.1/mhs.xsd https://zeticon.mediahaven.com/metadata/25.1/mh/ https://zeticon.mediahaven.com/metadata/25.1/mh.xsd">
         </mhs:Sidecar>
-        <mhs:Sidecar xmlns:mh="https://zeticon.mediahaven.com/metadata/24.1/mh/"
-            xmlns:mhs="https://zeticon.mediahaven.com/metadata/24.1/mhs/"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="24.1" xsi:schemaLocation="https://zeticon.mediahaven.com/metadata/24.1/mhs/ https://zeticon.mediahaven.com/metadata/24.1/mhs.xsd https://zeticon.mediahaven.com/metadata/24.1/mh/ https://zeticon.mediahaven.com/metadata/24.1/mh.xsd">
+        <mhs:Sidecar xmlns:mh="https://zeticon.mediahaven.com/metadata/25.1/mh/"
+            xmlns:mhs="https://zeticon.mediahaven.com/metadata/25.1/mhs/"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="25.1" xsi:schemaLocation="https://zeticon.mediahaven.com/metadata/25.1/mhs/ https://zeticon.mediahaven.com/metadata/25.1/mhs.xsd https://zeticon.mediahaven.com/metadata/25.1/mh/ https://zeticon.mediahaven.com/metadata/25.1/mh.xsd">
         </mhs:Sidecar>
     </Results>
 </root>

--- a/tests/resources/mh_api_responses/query_result_single_result.xml
+++ b/tests/resources/mh_api_responses/query_result_single_result.xml
@@ -3,9 +3,9 @@
     <TotalNrOfResults>1</TotalNrOfResults>
     <StartIndex>0</StartIndex>
     <Results>
-<mhs:Sidecar xmlns:mh="https://zeticon.mediahaven.com/metadata/24.1/mh/"
-    xmlns:mhs="https://zeticon.mediahaven.com/metadata/24.1/mhs/"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="24.1" xsi:schemaLocation="https://zeticon.mediahaven.com/metadata/24.1/mhs/ https://zeticon.mediahaven.com/metadata/24.1/mhs.xsd https://zeticon.mediahaven.com/metadata/24.1/mh/ https://zeticon.mediahaven.com/metadata/24.1/mh.xsd">
+<mhs:Sidecar xmlns:mh="https://zeticon.mediahaven.com/metadata/25.1/mh/"
+    xmlns:mhs="https://zeticon.mediahaven.com/metadata/25.1/mhs/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="25.1" xsi:schemaLocation="https://zeticon.mediahaven.com/metadata/25.1/mhs/ https://zeticon.mediahaven.com/metadata/25.1/mhs.xsd https://zeticon.mediahaven.com/metadata/25.1/mh/ https://zeticon.mediahaven.com/metadata/25.1/mh.xsd">
     <mhs:Descriptive>
         <mh:Title>Something</mh:Title>
         <mh:Description>Something descriptive</mh:Description>

--- a/tests/resources/transformation_results/sidecar.xml
+++ b/tests/resources/transformation_results/sidecar.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<mhs:Sidecar xmlns:mhs="https://zeticon.mediahaven.com/metadata/24.1/mhs/" xmlns:mh="https://zeticon.mediahaven.com/metadata/24.1/mh/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="24.1">
+<mhs:Sidecar xmlns:mhs="https://zeticon.mediahaven.com/metadata/25.1/mhs/" xmlns:mh="https://zeticon.mediahaven.com/metadata/25.1/mh/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="25.1">
   <mhs:Descriptive>
     <mh:Title>Something</mh:Title>
     <mh:Description>Something descriptive</mh:Description>


### PR DESCRIPTION
The MediaHaven namespaces contain the version number of the current MH version. An upgrade of MH results in a change in said namespaces in the returned results. Adapt the XSLT so that the transformation uses the correct namespaces (25.1).