### PR TITLE
DEV-2784 Fix deserializing error for missing MediaHaven ID in Premis-event

### DIFF
--- a/app/api/routers/event.py
+++ b/app/api/routers/event.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, BackgroundTasks, Depends
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from viaa.configuration import ConfigParser
 from viaa.observability import logging
 from mediahaven import MediaHaven
@@ -29,19 +29,19 @@ async def handle_events(
     """
     Returns OK if the xml parsing didn't crash.
     """
-    events = premis_events.events
-
-    archived_events = [
-        event for event in events if event.is_valid and event.has_valid_outcome
-    ]
-
-    log.debug(
-        f"Got {len(events)} PREMIS-event(s) of which {len(archived_events)} archived-event(s) with outcome OK."
-    )
-
-    for event in archived_events:
-        background_tasks.add_task(handle_event, event, mh_client)
-
-    return {
-        "message": f"Updating {len(archived_events)} item(s) with metadata from the original fragment in the background."
-    }
+    log.debug("Returned premis_events: '%s'" % premis_events)
+    if premis_events:
+        events = premis_events.events
+        archived_events = [
+            event for event in events if event.is_valid and event.has_valid_outcome
+        ]
+        log.debug(
+            f"Got {len(events)} PREMIS-event(s) of which {len(archived_events)} archived-event(s) with outcome OK."
+        )
+        for event in archived_events:
+            background_tasks.add_task(handle_event, event, mh_client)
+        return {
+            "message": f"Updating {len(archived_events)} item(s) with metadata from the original fragment in the background."
+        }
+    else:
+        raise HTTPException(status_code=400, detail="Could not validate or parse request body.")

--- a/app/api/routers/health.py
+++ b/app/api/routers/health.py
@@ -13,5 +13,4 @@ async def liveness_check():
     """
     Returns OK if the service is running.
     """
-    log.debug("Health/live called")
     return "OK"

--- a/app/api/routers/health.py
+++ b/app/api/routers/health.py
@@ -1,11 +1,17 @@
 from fastapi import APIRouter
+#
+from viaa.configuration import ConfigParser
+from viaa.observability import logging
 
 router = APIRouter()
 
+config = ConfigParser()
+log = logging.get_logger(__name__, config=config)
 
 @router.get("/live")
 async def liveness_check():
     """
     Returns OK if the service is running.
     """
+    log.debug("Health/live called")
     return "OK"

--- a/app/app.py
+++ b/app/app.py
@@ -16,7 +16,7 @@ log = logging.get_logger(__name__, config=config)
 _mediahaven_client: MediaHaven = None
 
 def mask(input_string: str):
-    return '***'.join([input_string[0:3], input_string[-3:]])
+    return '***'.join([input_string[0:2], input_string[-2:]])
 
 @app.on_event("startup")
 async def startup_event():
@@ -25,7 +25,7 @@ async def startup_event():
     client_id = mediahaven_config["client_id"]
     client_secret = mediahaven_config["client_secret"]
     user = mediahaven_config["username"]
-    log.debug("Using username '%s'" % user)
+    log.debug("Using username '%s'" % mask(user))
     password = mediahaven_config["password"]
     url = mediahaven_config["host"]
     log.debug("Using client_id '%s'" % mask(client_id))

--- a/app/app.py
+++ b/app/app.py
@@ -15,6 +15,8 @@ config = ConfigParser()
 log = logging.get_logger(__name__, config=config)
 _mediahaven_client: MediaHaven = None
 
+def mask(input_string: str):
+    return '***'.join([input_string[0:3], input_string[-3:]])
 
 @app.on_event("startup")
 async def startup_event():
@@ -23,8 +25,10 @@ async def startup_event():
     client_id = mediahaven_config["client_id"]
     client_secret = mediahaven_config["client_secret"]
     user = mediahaven_config["username"]
+    log.debug("Using username '%s'" % user)
     password = mediahaven_config["password"]
     url = mediahaven_config["host"]
+    log.debug("Using client_id '%s'" % mask(client_id))
     grant = ROPCGrant(url, client_id, client_secret)
     try:
         grant.request_token(user, password)

--- a/app/core/events_parser.py
+++ b/app/core/events_parser.py
@@ -1,9 +1,17 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+# Std
 from io import BytesIO
-
+# 3rd
 from lxml import etree
+# meemoo
+from viaa.configuration import ConfigParser
+from viaa.observability import logging
+
+
+config = ConfigParser()
+log = logging.get_logger(__name__, config=config)
 
 # Constants
 PREMIS_NAMESPACE = "info:lc/xmlns/premis-v2"
@@ -27,7 +35,17 @@ XPATHS = {
 
 
 def parse_premis_events(input_xml: bytes):
-    tree = etree.parse(BytesIO(input_xml))
+    log.debug("input_xml: %s" % input_xml)
+    try:
+        assert input_xml, "input_xml is empty?"
+    except AssertionError as e:
+        log.error("Missing request body: %s" % e)
+        return None
+    try:
+        tree = etree.parse(BytesIO(input_xml))
+    except etree.XMLSyntaxError as e:
+        log.error("Unparsable XML: %s" % e)
+        return None
 
     elements = tree.xpath("/events/p:event", namespaces={"p": PREMIS_NAMESPACE})
 

--- a/app/core/events_parser.py
+++ b/app/core/events_parser.py
@@ -36,10 +36,8 @@ XPATHS = {
 
 def parse_premis_events(input_xml: bytes):
     log.debug("input_xml: %s" % input_xml)
-    try:
-        assert input_xml, "input_xml is empty?"
-    except AssertionError as e:
-        log.error("Missing request body: %s" % e)
+    if not input_xml:
+        log.error("Missing request body")
         return None
     try:
         tree = etree.parse(BytesIO(input_xml))

--- a/app/models/premis_events.py
+++ b/app/models/premis_events.py
@@ -9,7 +9,7 @@ class PremisEvent(BaseModel):
     event_detail: Optional[str]
     event_id: str
     event_outcome: str
-    mediahaven_id: str
+    mediahaven_id: Optional[str]
     external_id: str
     is_valid: bool
     has_valid_outcome: bool

--- a/app/models/xml_body.py
+++ b/app/models/xml_body.py
@@ -1,10 +1,18 @@
+# Std
 from typing import Callable, Generic, Type, TypeVar
-
+# 3trd
 from fastapi import Request
 from pydantic import BaseModel
+from pydantic.error_wrappers import ValidationError as PydanticValidationError
+# meemoo
+from viaa.configuration import ConfigParser
+from viaa.observability import logging
 
 T = TypeVar("T", bound=BaseModel)
 
+
+config = ConfigParser()
+log = logging.get_logger(__name__, config=config)
 
 class XmlBody(Generic[T]):
     def __init__(self, model_class: Type[T], parser: Callable):
@@ -14,5 +22,20 @@ class XmlBody(Generic[T]):
     async def __call__(self, request: Request) -> T:
         body = await request.body()
         dict_data = self.parser(body)
-
-        return self.model_class.parse_obj(dict_data)
+        log.debug("Dict from incoming body: '%s'" % dict_data)
+        try:
+            assert dict_data["events"], "No events in request body? -> %s" % dict_data
+        except (TypeError, AttributeError, KeyError, AssertionError) as e:
+            log.error(
+                "Could not properly parse/unpack PremisEvent (see: 'exception')",
+                exception=str(e),)
+            return None
+        try:
+            parsed_data = self.model_class.parse_obj(dict_data)
+        except PydanticValidationError as e:
+            log.error(
+                "Could not validate PremisEvent (see: 'exception')",
+                exception=str(e),)
+            return None
+        else:
+            return parsed_data

--- a/tests/core/test_events_parser.py
+++ b/tests/core/test_events_parser.py
@@ -81,9 +81,12 @@ def test_multi_event():
     assert p["events"][2]["is_valid"]
 
 
-def test_invalid_xml_event():
-    with pytest.raises(XMLSyntaxError):
-        parse_premis_events(invalid_xml_event)
+def test_invalid_xml_event(caplog):
+    p = parse_premis_events(invalid_xml_event)
+    assert p is None
+    assert "error" in [record.levelname.lower() for record in caplog.records]
+    err_rec = [rec for rec in caplog.records if rec.levelname.lower() == "error"][0]
+    assert "Unparsable XML" in err_rec.message
 
 
 def test_single_event_no_external_id():


### PR DESCRIPTION
This fixes the crashing of the application in case of a missing MediaHaven ID in the incoming Premis-event.

Frankly, only the changes in `app/models/premis_events.py` (46403e623e1814752ffebf139edf3ede2301838c) were needed but more logging was added and more edge-cases are now handled.

We also return '400' to the caller if things get nasty.